### PR TITLE
Fix bug preventing calling t.Done() on throttler

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -111,19 +111,26 @@ func (h *Hasher) HashReaders(readers []io.Reader) (*HashSetList, error) {
 	ret := make(HashSetList, len(readers))
 	errs := []error{}
 
-	var mutex sync.Mutex
+	var (
+		retMu sync.Mutex
+		errMu sync.Mutex
+	)
 	t := throttler.New((4), len(readers))
 	for i, r := range readers {
 		go func() {
-			hashes, err := h.hashReader(r)
+			var err error
+			defer func() { t.Done(err) }()
+			var hashes *HashSet
+			hashes, err = h.hashReader(r)
 			if err != nil {
+				errMu.Lock()
 				errs = append(errs, err)
+				errMu.Unlock()
 				return
 			}
-			mutex.Lock()
+			retMu.Lock()
 			ret[i] = *hashes
-			mutex.Unlock()
-			t.Done(err)
+			retMu.Unlock()
 		}()
 		t.Throttle()
 	}


### PR DESCRIPTION
This pull request improves the concurrency safety and reliability of the `HashReaders` method in `hasher.go`. The main focus is on ensuring proper synchronization of shared resources and preventing deadlocks when errors occur during hashing.

Concurrency and error handling improvements:

* Added separate mutexes (`retMu` and `errMu`) to protect concurrent access to the `ret` and `errs` slices, ensuring thread safety when multiple goroutines update these shared resources.
* Ensured that `t.Done()` is always called using a `defer` statement, even if an error occurs, to prevent deadlocks in the throttler and downstream callers.